### PR TITLE
GitHub workflow: checkout repo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - uses: actions/checkout@v2
       - uses: dylan-lang/install-opendylan@v2
 
       - name: Build strings-test-suite-app


### PR DESCRIPTION
GitHub workflow: checkout repo

This fixes the workflow, but the workflow will not fail even if the test suite fails, due to using older versions of testworks and command-line-parser. I'm going to leave it this way for now since we plan to do a new OD release soon.