### PR TITLE
Continuous Integration of documents

### DIFF
--- a/.github/workflows/build-test-docs.yml
+++ b/.github/workflows/build-test-docs.yml
@@ -1,0 +1,47 @@
+name: Build and test documentation
+
+on:
+  push:
+    # all branches
+    paths:
+      - 'documentation/**/*.rst'
+      - 'documentation/**/conf.py'
+
+  pull_request:
+    # all branches
+    paths:
+      - 'documentation/**/*.rst'
+      - 'documentation/**/conf.py'
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build-documentation:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link check
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/documentation:/docs
+          run: make linkcheck
+
+      - name: Build docs with Furo theme
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/documentation:/docs
+          run: make html
+
+      - name: Upload html artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: strings-doc-html
+          path: documentation/build/html/

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ This is a strings library for Dylan providing common string and
 character functions.
 
 It was initially described in `DEP-0004
-<http://opendylan.org/proposals/dep-0004.html>`_.
+<https://opendylan.org/proposals/dep-0004-strings-library.html>`_.
 
 It is documented within the `Open Dylan Library Reference
 <http://opendylan.org/documentation/library-reference/>`_.

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -41,3 +41,6 @@ primary_domain = 'dylan'
 
 # sudo pip install -U furo
 html_theme = 'furo'
+
+# Ignore SNI validation errors
+tls_verify = False

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -8,8 +8,8 @@ The strings Library
 The *strings* library exports definitions for basic string manipulation.
 
 The *strings* library was originally defined in `DEP-0004
-<http://opendylan.org/proposals/dep-0004.html>`_.  Some additional background
-material can be found there.
+<https://opendylan.org/proposals/dep-0004-strings-library.html>`_. Some
+additional background material can be found there.
 
 .. toctree::
    :hidden:
@@ -32,8 +32,8 @@ material can be found there.
     will be updated to support it also.
 
 The strings library was originally defined in `DEP-0004
-<http://opendylan.org/proposals/dep-0004.html>`_.  Some additional
-background material can be found there.
+<https://opendylan.org/proposals/dep-0004-strings-library.html>`_. Some
+additional background material can be found there.
 
 
 The strings Module
@@ -806,7 +806,8 @@ Comparison Functions
 
 Case insensitive character comparison functions are provided for
 convenience.  (See `DEP-0004
-<http://opendylan.org/proposals/dep-0004.html>`_ for discussion.)
+<https://opendylan.org/proposals/dep-0004-strings-library.html>`_. for
+discussion.)
 
 .. function:: char-compare
 


### PR DESCRIPTION
Adds continuous integration for documentation

- Removes the validation of certificates in links so the `make linkcheck` test can pass. Before, the python library timeouts.
- Uses a docker container with `sphinx-contrib` inside. Dylan tool is not needed to download `sphinx-contrib` as a dependency. The compilation of `dylan-tool` is not needed either. It reduces the time of the test in a fith part. In the [repository of dylan-docs](https://github.com/fraya/dylan-docs) there is the [Dockerfile](https://github.com/fraya/dylan-docs/blob/main/Dockerfile) that creates the image and the [GH Action](https://github.com/fraya/dylan-docs/blob/main/.github/workflows/create-and-publish-docker-image.yml) shows the download of the sphinx-contrib package and the push of the image.
- Uploads the documentation as an asset.
- As result of the process four broken links where detected.