### PR TITLE
Add license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Carl Gay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,12 +1,14 @@
 {
-    "dependencies": [],
+    "name": "strings",
     "category": "utilities",
+    "license": "MIT",
+    "license-url": "https://opensource.org/license/mit",
+    "dependencies": [],
     "dev-dependencies": [
         "sphinx-extensions",
         "testworks"
     ],
     "description": "String manipulation functions",
-    "name": "strings",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "url": "https://github.com/dylan-lang/strings"
 }


### PR DESCRIPTION
This was always intended to be licensed with my usual MIT licensy goodness; now it is.